### PR TITLE
Shell Tab Completions

### DIFF
--- a/.templates/rsb_mvp_vm_module/Code/ViewController.swift.stencil
+++ b/.templates/rsb_mvp_vm_module/Code/ViewController.swift.stencil
@@ -1,6 +1,7 @@
 {% include "header.stencil" %}
 
 import UIKit
+import protocol Base.ForceViewUpdate
 
 protocol {{ name | upperFirstLetter }}ViewInput: class {
     func update(with viewModel: {{ name | upperFirstLetter }}ViewModel, force: Bool, animated: Bool)

--- a/General.xcodeproj/project.pbxproj
+++ b/General.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		019849AC2508D5F300D217B4 /* ColorString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019849AA2508D5EC00D217B4 /* ColorString.swift */; };
 		01F8D828250105CC00903BF7 /* FileInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F8D8242501055D00903BF7 /* FileInfo.swift */; };
 		01F8D82B2501096A00903BF7 /* FileHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F8D8292501092800903BF7 /* FileHelper.swift */; };
+		EC4AAC7B828B4681F8FA467E /* CompletionsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC40E89D221F9C42B9787468 /* CompletionsService.swift */; };
 		OBJ_310 /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_158 /* Document.swift */; };
 		OBJ_311 /* Element.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_159 /* Element.swift */; };
 		OBJ_312 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_160 /* Error.swift */; };
@@ -291,203 +292,203 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "ZIPFoundation::ZIPFoundation";
+			remoteGlobalIDString = ZIPFoundation::ZIPFoundation;
 			remoteInfo = ZIPFoundation;
 		};
 		01F8D809250100E900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "XcodeProj::XcodeProj";
+			remoteGlobalIDString = XcodeProj::XcodeProj;
 			remoteInfo = XcodeProj;
 		};
 		01F8D80A250100E900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "AEXML::AEXML";
+			remoteGlobalIDString = AEXML::AEXML;
 			remoteInfo = AEXML;
 		};
 		01F8D80B250100E900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "PathKit::PathKit";
+			remoteGlobalIDString = PathKit::PathKit;
 			remoteInfo = PathKit;
 		};
 		01F8D80C250100E900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "XcodeProjCExt::XcodeProjCExt";
+			remoteGlobalIDString = XcodeProjCExt::XcodeProjCExt;
 			remoteInfo = XcodeProjCExt;
 		};
 		01F8D80D250100E900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "AEXML::AEXML";
+			remoteGlobalIDString = AEXML::AEXML;
 			remoteInfo = AEXML;
 		};
 		01F8D80E250100E900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "XcodeProjCExt::XcodeProjCExt";
+			remoteGlobalIDString = XcodeProjCExt::XcodeProjCExt;
 			remoteInfo = XcodeProjCExt;
 		};
 		01F8D80F250100E900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "Yams::Yams";
+			remoteGlobalIDString = Yams::Yams;
 			remoteInfo = Yams;
 		};
 		01F8D810250100E900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "Yams::CYaml";
+			remoteGlobalIDString = Yams::CYaml;
 			remoteInfo = CYaml;
 		};
 		01F8D811250100E900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "Yams::CYaml";
+			remoteGlobalIDString = Yams::CYaml;
 			remoteInfo = CYaml;
 		};
 		01F8D812250100E900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "swift-argument-parser::ArgumentParser";
+			remoteGlobalIDString = swift-argument-parser::ArgumentParser;
 			remoteInfo = ArgumentParser;
 		};
 		01F8D813250100E900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "StencilSwiftKit::StencilSwiftKit";
+			remoteGlobalIDString = StencilSwiftKit::StencilSwiftKit;
 			remoteInfo = StencilSwiftKit;
 		};
 		01F8D814250100E900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "Stencil::Stencil";
+			remoteGlobalIDString = Stencil::Stencil;
 			remoteInfo = Stencil;
 		};
 		01F8D815250100E900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "PathKit::PathKit";
+			remoteGlobalIDString = PathKit::PathKit;
 			remoteInfo = PathKit;
 		};
 		01F8D816250100E900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "PathKit::PathKit";
+			remoteGlobalIDString = PathKit::PathKit;
 			remoteInfo = PathKit;
 		};
 		01F8D817250100E900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "Stencil::Stencil";
+			remoteGlobalIDString = Stencil::Stencil;
 			remoteInfo = Stencil;
 		};
 		01F8D818250100E900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "PathKit::PathKit";
+			remoteGlobalIDString = PathKit::PathKit;
 			remoteInfo = PathKit;
 		};
 		01F8D819250100EA00903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "General::General";
+			remoteGlobalIDString = General::General;
 			remoteInfo = General;
 		};
 		01F8D81A250100EA00903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "ZIPFoundation::ZIPFoundation";
+			remoteGlobalIDString = ZIPFoundation::ZIPFoundation;
 			remoteInfo = ZIPFoundation;
 		};
 		01F8D81B250100EA00903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "XcodeProj::XcodeProj";
+			remoteGlobalIDString = XcodeProj::XcodeProj;
 			remoteInfo = XcodeProj;
 		};
 		01F8D81C250100EA00903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "AEXML::AEXML";
+			remoteGlobalIDString = AEXML::AEXML;
 			remoteInfo = AEXML;
 		};
 		01F8D81D250100EA00903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "XcodeProjCExt::XcodeProjCExt";
+			remoteGlobalIDString = XcodeProjCExt::XcodeProjCExt;
 			remoteInfo = XcodeProjCExt;
 		};
 		01F8D81E250100EA00903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "Yams::Yams";
+			remoteGlobalIDString = Yams::Yams;
 			remoteInfo = Yams;
 		};
 		01F8D81F250100EA00903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "Yams::CYaml";
+			remoteGlobalIDString = Yams::CYaml;
 			remoteInfo = CYaml;
 		};
 		01F8D820250100EA00903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "swift-argument-parser::ArgumentParser";
+			remoteGlobalIDString = swift-argument-parser::ArgumentParser;
 			remoteInfo = ArgumentParser;
 		};
 		01F8D821250100EA00903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "StencilSwiftKit::StencilSwiftKit";
+			remoteGlobalIDString = StencilSwiftKit::StencilSwiftKit;
 			remoteInfo = StencilSwiftKit;
 		};
 		01F8D822250100EA00903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "Stencil::Stencil";
+			remoteGlobalIDString = Stencil::Stencil;
 			remoteInfo = Stencil;
 		};
 		01F8D823250100EA00903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "PathKit::PathKit";
+			remoteGlobalIDString = PathKit::PathKit;
 			remoteInfo = PathKit;
 		};
 		01F8D827250105C900903BF7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "General::GeneralTests";
+			remoteGlobalIDString = General::GeneralTests;
 			remoteInfo = GeneralTests;
 		};
 /* End PBXContainerItemProxy section */
@@ -497,6 +498,7 @@
 		01F8D8242501055D00903BF7 /* FileInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileInfo.swift; sourceTree = "<group>"; };
 		01F8D8292501092800903BF7 /* FileHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHelper.swift; sourceTree = "<group>"; };
 		"AEXML::AEXML::Product" /* AEXML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AEXML.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EC40E89D221F9C42B9787468 /* CompletionsService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompletionsService.swift; sourceTree = "<group>"; };
 		"General::General::Product" /* General */ = {isa = PBXFileReference; lastKnownFileType = text; path = General; sourceTree = BUILT_PRODUCTS_DIR; };
 		"General::GeneralTests::Product" /* GeneralTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = GeneralTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_10 /* Create.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Create.swift; sourceTree = "<group>"; };
@@ -1475,6 +1477,7 @@
 				OBJ_28 /* main.swift */,
 				01F8D8292501092800903BF7 /* FileHelper.swift */,
 				019849AA2508D5EC00D217B4 /* ColorString.swift */,
+				EC40E89D221F9C42B9787468 /* CompletionsService.swift */,
 			);
 			name = General;
 			path = Sources/General;
@@ -2062,6 +2065,7 @@
 				OBJ_399 /* URL+Paths.swift in Sources */,
 				OBJ_400 /* main.swift in Sources */,
 				01F8D82B2501096A00903BF7 /* FileHelper.swift in Sources */,
+				EC4AAC7B828B4681F8FA467E /* CompletionsService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ bindir = $(prefix)/bin
 binary ?= general
 release_binary?=.build/release/General
 
-install: build completion
+install: build completions
 	mkdir -p $(bindir)
 	cp -f $(release_binary) $(bindir)/$(binary)
 
@@ -16,7 +16,9 @@ uninstall:
 clean:
 	rm -rf .build
 
-completion:
-	general --generate-completion-script zsh > /usr/local/share/zsh/site-functions/_general
+completions:
+	general --generate-completion-script zsh > _general
+	general --generate-completion-script bash > general
+	general --generate-completion-script fish > general.fish
 
 .PHONY: build install uninstall clean

--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,20 @@ bindir = $(prefix)/bin
 binary ?= general
 release_binary?=.build/release/General
 
-build:
-	swift build -c release --disable-sandbox
-
-install: build
+install: build completion
 	mkdir -p $(bindir)
 	cp -f $(release_binary) $(bindir)/$(binary)
+
+build:
+	swift build -c release --disable-sandbox
 
 uninstall:
 	rm -rf "$(bindir)/$(binary)"
 
 clean:
 	rm -rf .build
+
+completion:
+	general --generate-completion-script zsh > /usr/local/share/zsh/site-functions/_general
 
 .PHONY: build install uninstall clean

--- a/Sources/General/Commands/Create.swift
+++ b/Sources/General/Commands/Create.swift
@@ -17,7 +17,7 @@ final class Create: ParsableCommand {
     @Option(name: .shortAndLong, help: "The name of the template.")
     var template: String
 
-    @Option(name: .shortAndLong, help: "The path for the template.")
+    @Option(name: .shortAndLong, help: "The path for the template.", completion: .directory)
     var path: String?
 
     func run() throws {

--- a/Sources/General/Commands/Generate.swift
+++ b/Sources/General/Commands/Generate.swift
@@ -30,22 +30,22 @@ final class Generate: ParsableCommand {
 
     static let configuration: CommandConfiguration = .init(commandName: "gen", abstract: "Generates modules from templates.")
 
-    @Option(name: .shortAndLong, help: "The path for the project.")
+    @Option(name: .shortAndLong, completion: .directory, help: "The path for the project.")
     var path: String = FileManager.default.currentDirectoryPath
 
     @Option(name: .shortAndLong, help: "The name of the module.")
     var name: String
 
-    @Option(name: .shortAndLong, help: "The name of the template.")
+    @Option(name: .shortAndLong, help: "The name of the template.", completion: .templates)
     var template: String
 
-    @Option(name: .shortAndLong, help: "The output for the template.")
+    @Option(name: .shortAndLong, help: "The output for the template.", completion: .directory)
     var output: String?
 
-    @Option(name: .long, help: "The target to which add files.")
+    @Option(name: .long, help: "The target to which add files.", completion: .targets)
     var target: String?
 
-    @Option(name: .long, help: "The test target to which add test files.")
+    @Option(name: .long, help: "The test target to which add test files.", completion: .targets)
     var testTarget: String?
 
     @Argument(help: "The additional variables for templates.")
@@ -67,6 +67,7 @@ final class Generate: ParsableCommand {
     // MARK: - Lifecycle
 
     func run() throws {
+        print(path)
         //create environment and spec
         let templatesURL = defineTemplatesURL()
         let templateURL = templatesURL + template

--- a/Sources/General/Commands/Generate.swift
+++ b/Sources/General/Commands/Generate.swift
@@ -42,10 +42,10 @@ final class Generate: ParsableCommand {
     @Option(name: .shortAndLong, help: "The output for the template.")
     var output: String?
 
-    @Option(name: .shortAndLong, help: "The target to which add files.")
+    @Option(name: .long, help: "The target to which add files.")
     var target: String?
 
-    @Option(name: .shortAndLong, help: "The test target to which add test files.")
+    @Option(name: .long, help: "The test target to which add test files.")
     var testTarget: String?
 
     @Argument(help: "The additional variables for templates.")

--- a/Sources/General/Commands/Generate.swift
+++ b/Sources/General/Commands/Generate.swift
@@ -67,7 +67,6 @@ final class Generate: ParsableCommand {
     // MARK: - Lifecycle
 
     func run() throws {
-        print(path)
         //create environment and spec
         let templatesURL = defineTemplatesURL()
         let templateURL = templatesURL + template

--- a/Sources/General/Commands/Generate.swift
+++ b/Sources/General/Commands/Generate.swift
@@ -30,8 +30,8 @@ final class Generate: ParsableCommand {
 
     static let configuration: CommandConfiguration = .init(commandName: "gen", abstract: "Generates modules from templates.")
 
-    @Option(name: .shortAndLong, default: FileManager.default.currentDirectoryPath, help: "The path for the project.")
-    var path: String
+    @Option(name: .shortAndLong, help: "The path for the project.")
+    var path: String = FileManager.default.currentDirectoryPath
 
     @Option(name: .shortAndLong, help: "The name of the module.")
     var name: String
@@ -41,6 +41,12 @@ final class Generate: ParsableCommand {
 
     @Option(name: .shortAndLong, help: "The output for the template.")
     var output: String?
+
+    @Option(name: .shortAndLong, help: "The target to which add files.")
+    var target: String?
+
+    @Option(name: .shortAndLong, help: "The test target to which add test files.")
+    var testTarget: String?
 
     @Argument(help: "The additional variables for templates.")
     var variables: [Variable] = []
@@ -73,9 +79,9 @@ final class Generate: ParsableCommand {
             try projectService.createProject(projectName: projectName)
         }
 
-        try add(templateSpec.files, to: generalSpec?.target, isTestTarget: false, with: environment)
+        try add(templateSpec.files, to: targetName(), isTestTarget: false, with: environment)
         if let testFiles = templateSpec.testFiles {
-            try add(testFiles, to: generalSpec?.testTarget, isTestTarget: true, with: environment)
+            try add(testFiles, to: testTargetName(), isTestTarget: true, with: environment)
         }
         try projectService.write()
         print("🎉 \(template) template with \(name) name was successfully generated.")
@@ -157,6 +163,14 @@ final class Generate: ParsableCommand {
             try projectService.addFile(targetName: target, isTestTarget: isTestTarget,
                                        filePath: Path(fileURL.path))
         }
+    }
+
+    private func targetName(spec: GeneralSpec? = nil) -> String? {
+        target ?? (spec ?? generalSpec)?.target
+    }
+
+    private func testTargetName(spec: GeneralSpec? = nil) -> String? {
+        testTarget ?? (spec ?? generalSpec)?.testTarget
     }
 }
 

--- a/Sources/General/Commands/Generate.swift
+++ b/Sources/General/Commands/Generate.swift
@@ -112,8 +112,8 @@ final class Generate: ParsableCommand {
         var paths = [Path(commonTemplatesURL.path), Path(templateURL.path)]
         paths.append(contentsOf: directoryPaths)
         let environment = Environment(loader: FileSystemLoader(paths: paths))
-        environment.extensions.forEach { `extension` in
-            `extension`.registerStencilSwiftExtensions()
+        environment.extensions.forEach { ext in
+            ext.registerStencilSwiftExtensions()
         }
         return environment
     }

--- a/Sources/General/Commands/Setup.swift
+++ b/Sources/General/Commands/Setup.swift
@@ -232,7 +232,7 @@ final class Setup: ParsableCommand {
         guard var spec: GeneralSpec = try? specFactory.makeSpec(url: templateURL) else {
             return false
         }
-        spec.project = ask("Enter project name", default: try findProject())
+        spec.project = ask("Enter project name", default: try ProjectService.findProject()?.description)
         spec.target = ask("Target (optional)")
         spec.testTarget = ask("Test target (optional)")
         spec.company = ask("Company (optional)", default: spec.company)
@@ -274,13 +274,6 @@ final class Setup: ParsableCommand {
             return `default`
         }
         return value
-    }
-
-    private func findProject() throws -> String? {
-        let info = try fileHelper.contentsOfDirectory(at: Constants.relativeCurrentPath).first { info in
-            info.url.pathExtension == Constants.xcodeProjectPathExtension
-        }
-        return info?.url.lastPathComponent
     }
 
     private func displayResult(_ templates: [FileInfo], isSpecModified: Bool) {

--- a/Sources/General/Commands/Setup.swift
+++ b/Sources/General/Commands/Setup.swift
@@ -232,7 +232,7 @@ final class Setup: ParsableCommand {
         guard var spec: GeneralSpec = try? specFactory.makeSpec(url: templateURL) else {
             return false
         }
-        spec.project = ask("Enter project name", default: try ProjectService.findProject()?.description)
+        spec.project = ask("Enter project name", default: try ProjectService.findProject()?.url.lastPathComponent)
         spec.target = ask("Target (optional)")
         spec.testTarget = ask("Test target (optional)")
         spec.company = ask("Company (optional)", default: spec.company)

--- a/Sources/General/Commands/Spec.swift
+++ b/Sources/General/Commands/Spec.swift
@@ -14,8 +14,8 @@ final class Spec: ParsableCommand {
 
     static let configuration: CommandConfiguration = .init(abstract: "Creates a new spec.")
 
-    @Option(name: .shortAndLong, default: FileManager.default.currentDirectoryPath, help: "The path for the template.")
-    var path: String
+    @Option(name: .shortAndLong, completion: .directory, help: "The path for the template.")
+    var path: String = FileManager.default.currentDirectoryPath
 
     func run() throws {
         //folder url for a new spec

--- a/Sources/General/CompletionsService.swift
+++ b/Sources/General/CompletionsService.swift
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Rosberry. All rights reserved.
+//  Copyright © 2020 Rosberry. All rights reserved.
 //
 
 import Foundation
@@ -23,7 +23,7 @@ extension CompletionKind {
             CompletionsService.templates()
         }
     }
-    
+
     static var targets: CompletionKind {
         .custom { _ in
             CompletionsService.targets()

--- a/Sources/General/CompletionsService.swift
+++ b/Sources/General/CompletionsService.swift
@@ -1,0 +1,32 @@
+//
+// Copyright © 2020 Rosberry. All rights reserved.
+//
+
+import Foundation
+import XcodeProj
+import ArgumentParser
+
+final class CompletionsService {
+
+    static func templates() -> [String] {
+        (try? FileManager.default.contentsOfDirectory(atPath: "./\(Constants.templatesFolderName)")) ?? []
+    }
+
+    static func targets() -> [String] {
+        (try? XcodeProj(path: "./General.xcodeproj").pbxproj.nativeTargets.map { $0.name }) ?? []
+    }
+}
+
+extension CompletionKind {
+    static var templates: CompletionKind {
+        .custom { _ in
+            CompletionsService.templates()
+        }
+    }
+    
+    static var targets: CompletionKind {
+        .custom { _ in
+            CompletionsService.targets()
+        }
+    }
+}

--- a/Sources/General/CompletionsService.swift
+++ b/Sources/General/CompletionsService.swift
@@ -13,7 +13,10 @@ final class CompletionsService {
     }
 
     static func targets() -> [String] {
-        (try? XcodeProj(path: "./General.xcodeproj").pbxproj.nativeTargets.map { $0.name }) ?? []
+        guard let projectPath = try? ProjectService.findProject() else {
+            return []
+        }
+        return (try? XcodeProj(path: projectPath).pbxproj.nativeTargets.map { $0.name }) ?? []
     }
 }
 

--- a/Sources/General/ProjectService.swift
+++ b/Sources/General/ProjectService.swift
@@ -21,6 +21,10 @@ final class ProjectService {
     init(path: Path) {
         self.path = path
     }
+    
+    static func findProject() throws -> Path? {
+        try Path.current.children().first { $0.extension == Constants.xcodeProjectPathExtension  }
+    }
 
     func createProject(projectName: String) throws {
         let xcodeprojPath = path + Path(projectName)

--- a/Sources/General/ProjectService.swift
+++ b/Sources/General/ProjectService.swift
@@ -21,9 +21,9 @@ final class ProjectService {
     init(path: Path) {
         self.path = path
     }
-    
+
     static func findProject() throws -> Path? {
-        try Path.current.children().first { $0.extension == Constants.xcodeProjectPathExtension  }
+        try Path.current.children().first { $0.extension == Constants.xcodeProjectPathExtension }
     }
 
     func createProject(projectName: String) throws {
@@ -112,10 +112,10 @@ extension ProjectService.Error: CustomStringConvertible {
 
     var description: String {
         switch self {
-            case .noProject(let path):
-                return "There is no pbxproj at " + path
-            case .noGroup:
-                return "Fail to add groups to Xcode project."
+        case .noProject(let path):
+            return "There is no pbxproj at " + path
+        case .noGroup:
+            return "Fail to add groups to Xcode project."
         }
     }
 }


### PR DESCRIPTION
## Description
Add shell tab completions. The completions scripts are generated by `--generate-completion-script` (`make completions`).

Regarding this there were updates in source code -- some options require specification of `completionKind`:
- on `--template` completion it looks into contents of `.templates` directory
- on `--target` and `--test-target` it looks for `.xcodeproj` in current directory and get its targets

## Related tasks
[ISD-356](https://rosberry.atlassian.net/secure/RapidBoard.jspa?rapidView=124&view=planning&selectedIssue=ISD-356)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] Have merged develop branch
- [X] Develop branch is chosen as a merge branch
- [X] The appropriate pull request label is selected (Ready | WIP)
- [X] Follows code style
- [X] Has no SwiftLint warnings
- [X] Retain cycles were checked
- [X] Has no force unwraps
- [X] Access control words were checked